### PR TITLE
fix(ops): Cap node to v11, as node v12 and gulp v3 are incompatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:css": "stylelint src/styles/**/*.scss"
   },
   "engines": {
-    "node": ">=6.5.0",
+    "node": "^11.0.0",
     "npm": ">=3.10.5"
   },
   "keywords": [


### PR DESCRIPTION
Recent deployment of the starter kit have been breaking because Gulp is set to v3 and the latest node (v12) is incompatible.

SO question similar to error being produced and source of fix: https://stackoverflow.com/q/55921442/390866